### PR TITLE
Expand README with features and API details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# Fantasy Forum 
-THE ULTIMATE PLACE TO DISCUSS ALL STUFF FANTASY, WHETHER THAT MEANS A SIMPLE TRADE QUESTION OR JUST SHOWING OFF YOUR KNOWLEDGE. SEE HOW THE PEOPLE FEEL ABOUT PLAYERS, HEAR THE LATEST UPDATES AND WIN YOUR LEAGUE
+# Fantasy Forum
+THE ULTIMATE PLACE TO DISCUSS ALL STUFF FANTASY, WHETHER THAT MEANS A SIMPLE TRADE QUESTION OR JUST SHOWING OFF YOUR KNOWLEDGE.
+SEE HOW THE PEOPLE FEEL ABOUT PLAYERS, HEAR THE LATEST UPDATES AND WIN YOUR LEAGUE.
 
-Here is a minimal guide to run the Flask app locally.
+Here is a complete guide to running and exploring the Flask app locally.
+
+## What you get
+- User registration/login with password hashing and persistent sessions.
+- Create, edit, delete, and comment on posts with flairs for **TRADE HELP**, **WAIVER WIRE ADVICE**, **INJURY TALK**, or **OTHER**.
+- Search and pagination for posts via the JSON API.
+- Health checks and Prometheus-friendly metrics (with a lightweight fallback when `prometheus_client` is not installed).
+- Optional Azure Application Insights tracing when the `opencensus-ext-azure` dependency is available.
 
 ## NEED
-- Python 3.10+ 
+- Python 3.10+
+- (Optional) Docker + Docker Compose for containerized runs
 
 ## 1) Clone / open the project
 ```bash
@@ -35,16 +44,34 @@ pip install -r requirements.txt
 python app.py
 ```
 - The server should be live and you can open at: http://127.0.0.1:5000
+- The SQLite database is created automatically (including the `flair` column) when the server starts.
 
+## 5) Useful pages
+- Home (`/`): See all posts that are being made by other people (filter by flair from the UI).
+- About (`/about`): Quick summary of the project.
+- API Demo (`/api-demo`): Search posts and download JSON exports without leaving the browser.
+- Login/Register (`/login`, `/register`): Create an account to publish or comment.
+- Posts: Create `/post/new`, edit `/post/<id>/edit`, delete `/post/<id>/delete`, and view `/post/<id>`.
+- Health + monitoring: `/health` and `/api/health` return `{"status": "ok"}`; `/metrics` exposes Prometheus metrics.
 
-## Useful pages
-- Home: See all posts that are being made by other people
-- About: The about page is just a quick summary of the project and what its about, the true read me
-- API Demo: Extra tools for potential search of posts and data, download of JSON and helpful for people who want the data
-- Login/Register: Make an account, if you already have one then ust login with it, after successfully doing that you will now be able to post, edit and comment stuff
-- Posts: You can create, edit, delete your own posts and can comment on others post 
+## 6) JSON API quick reference
+- `GET /api/posts?flair=<flair>&q=<text>&page=<page>&per_page=<1-50>`: Paginated posts with optional text search and flair filter.
+- `GET /api/posts/<id>`: Single post payload including content.
+- `GET /api/posts/<id>/comments`: Comments for a post.
+- `GET /api/stats`: Counts per flair plus the five latest posts.
+- `GET /api/export/posts`: Download all posts as a JSON file.
 
-## To Run Tests
+## 7) Docker (optional)
+```bash
+docker build -t fantasy-forum .
+docker run -p 5000:5000 fantasy-forum
+```
+Or use Compose:
+```bash
+docker-compose up --build
+```
+
+## 8) To Run Tests
 ```
 pytest --cov=app --cov-branch --cov-report=term-missing --cov-fail-under=90
 ```


### PR DESCRIPTION
## Summary
- expand the README with a full overview of features and monitoring endpoints
- document JSON API routes, health checks, and metrics
- add optional Docker/Compose instructions alongside existing setup steps

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccf2bb220832ba34a32e85aca612c)